### PR TITLE
Added (now required) handling options to integration messages sent by the SDK

### DIFF
--- a/canvas_workflow_helpers/protocols/appointment_coverage_check.py
+++ b/canvas_workflow_helpers/protocols/appointment_coverage_check.py
@@ -102,6 +102,9 @@ class AppointmentCoverageCheck(ClinicalQualityMeasure):
             update_payload = {
                 'integration_type': 'Task',
                 'integration_source': '',
+                'handling_options': {
+                    'respond_async': False
+                },
                 'patient_identifier': {
                     'identifier_type': 'key',
                     'identifier': {

--- a/canvas_workflow_helpers/protocols/appointment_task_creator.py
+++ b/canvas_workflow_helpers/protocols/appointment_task_creator.py
@@ -99,6 +99,9 @@ class AppointmentTaskCreator(ClinicalQualityMeasure):
             update_payload = {
                 'integration_type': 'Task',
                 'integration_source': '',
+                'handling_options': {
+                    'respond_async': False
+                },
                 'patient_identifier': {
                     'identifier_type': 'key',
                     'identifier': {

--- a/canvas_workflow_helpers/protocols/appointment_updater.py
+++ b/canvas_workflow_helpers/protocols/appointment_updater.py
@@ -63,6 +63,9 @@ class AppointmentUpdate(ClinicalQualityMeasure):
         update_payload = {
             'integration_type': 'Update Appointment',
             'integration_source': 'Protocol',
+            'handling_options': {
+                'respond_async': False
+            },
             'patient_identifier': {
                 'identifier_type': 'key',
                 'identifier': {


### PR DESCRIPTION
The way home-app processes integration messages changed slightly, and I forgot to update the SDK to account for this. This resulted in a regression that causes all integration messages sent by the SDK to home-app to be rejected.