### PR TITLE
Fix small typo in Protocol example

### DIFF
--- a/canvas_workflow_helpers/protocols/example_protocols/cervical_cancer_screening.py
+++ b/canvas_workflow_helpers/protocols/example_protocols/cervical_cancer_screening.py
@@ -173,7 +173,7 @@ class CervicalCancerScreening(ClinicalQualityMeasure):
                 result.add_recommendation(hpv_recommendation)
 
                 refer_recommendation = ReferRecommendation(
-                    key='RECOMMEND_REFER_COLONOSCOPY',
+                    key='RECOMMEND_REFER_OBGYN',
                     rank=3,
                     button='Refer',
                     patient=self.patient,


### PR DESCRIPTION
Typo in describing a referral.